### PR TITLE
feat: override go builder to use overriden go

### DIFF
--- a/lib/go/go.nix
+++ b/lib/go/go.nix
@@ -92,7 +92,7 @@ in
     , nativeBuildInputs
     , cgoEnabled ? 1
     , postInstall ? ""
-    }: (pkgs.buildGoNhostModule {
+    }: (pkgs.buildGoModule {
       inherit src version ldflags buildInputs nativeBuildInputs;
 
       pname = name;

--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -14,15 +14,15 @@ final: prev: rec {
 
   golangci-lint = prev.golangci-lint.override rec {
     buildGoModule = args: final.buildGoModule (args // rec {
-      version = "1.59.1";
+      version = "1.60.3";
       src = prev.fetchFromGitHub {
         owner = "golangci";
         repo = "golangci-lint";
         rev = "v${version}";
-        sha256 = "sha256-VFU/qGyKBMYr0wtHXyaMjS5fXKAHWe99wDZuSyH8opg=";
+        sha256 = "sha256-0ScdJ5td2N8WF1dwHQ3dBSjyr1kqgrzCfBzbRg9cRrw=";
       };
 
-      vendorHash = "sha256-yYwYISK1wM/mSlAcDSIwYRo8sRWgw2u+SsvgjH+Z/7M=";
+      vendorHash = "sha256-ixeswsfx36D0Tg103swbBD8UXXLNYbxSMYDE+JOm+uw=";
 
       ldflags = [
         "-s"

--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -13,7 +13,7 @@ final: prev: rec {
   buildGoModule = prev.buildGoModule.override { go = go; };
 
   golangci-lint = prev.golangci-lint.override rec {
-    buildGoModule = args: prev.final.buildGoModule (args // rec {
+    buildGoModule = args: final.buildGoModule (args // rec {
       version = "1.59.1";
       src = prev.fetchFromGitHub {
         owner = "golangci";

--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -10,10 +10,10 @@ final: prev: rec {
 
     });
 
-  buildGoNhostModule = prev.buildGoModule.override { go = go; };
+  buildGoModule = prev.buildGoModule.override { go = go; };
 
   golangci-lint = prev.golangci-lint.override rec {
-    buildGoModule = args: prev.buildGoModule.override { go = go; } (args // rec {
+    buildGoModule = args: prev.final.buildGoModule (args // rec {
       version = "1.59.1";
       src = prev.fetchFromGitHub {
         owner = "golangci";


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced custom `buildGoNhostModule` with standard `buildGoModule` in `lib/go/go.nix`
- Renamed `buildGoNhostModule` to `buildGoModule` in `overlays/go.nix` for consistency
- Updated `golangci-lint` configuration to use the new `buildGoModule` function
- These changes streamline the Go build process and ensure consistent use of the overridden Go version


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Update Go build function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/go/go.nix

- Changed `pkgs.buildGoNhostModule` to `pkgs.buildGoModule`



</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/20/files#diff-1377128cceefd42b43cd5e407ec11a809c7aaec2d071a1ed0e3232f6dce63fad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Refactor Go-related overlays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/go.nix

<li>Renamed <code>buildGoNhostModule</code> to <code>buildGoModule</code><br> <li> Updated <code>golangci-lint</code> to use <code>prev.final.buildGoModule</code> instead of a <br>custom override<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/20/files#diff-46da9fc0b23a2984c1ff57bfd4063ad81fccffcc8403f6902d186d679b4e52bd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

