### PR TITLE
core: bump golangci-lint due to some memory issues

### DIFF
--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -14,15 +14,15 @@ final: prev: rec {
 
   golangci-lint = prev.golangci-lint.override rec {
     buildGoModule = args: final.buildGoModule (args // rec {
-      version = "1.60.3";
+      version = "1.61.0";
       src = prev.fetchFromGitHub {
         owner = "golangci";
         repo = "golangci-lint";
         rev = "v${version}";
-        sha256 = "sha256-0ScdJ5td2N8WF1dwHQ3dBSjyr1kqgrzCfBzbRg9cRrw=";
+        sha256 = "sha256-2YzVNOdasal27R92l6eVdeS81mAp0ZU6kYsC/Jfvkcg=";
       };
 
-      vendorHash = "sha256-ixeswsfx36D0Tg103swbBD8UXXLNYbxSMYDE+JOm+uw=";
+      vendorHash = "sha256-mFDCRxbLq08yRd0ko3CCPJD2BZiCB0Gwd1g+/1oR6w8=";
 
       ldflags = [
         "-s"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgraded golangci-lint from version 1.60.3 to 1.61.0
- Updated the sha256 hash for the source to match the new version
- Updated the vendorHash to correspond with the new version
- This update addresses some memory issues mentioned in the commit message


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Upgrade golangci-lint to version 1.61.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/go.nix

<li>Updated golangci-lint version from 1.60.3 to 1.61.0<br> <li> Updated sha256 hash for the source<br> <li> Updated vendorHash<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/22/files#diff-46da9fc0b23a2984c1ff57bfd4063ad81fccffcc8403f6902d186d679b4e52bd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

