### PR TITLE
chore: update nixops

### DIFF
--- a/.github/workflows/gen_ai_review.yaml
+++ b/.github/workflows/gen_ai_review.yaml
@@ -25,4 +25,4 @@ jobs:
           config.max_model_tokens: 100000
           config.model: "anthropic/claude-3-5-sonnet-20240620"
           config.model_turbo: "anthropic/claude-3-5-sonnet-20240620"
-          config.ignore.glob: "vendor/**,**/client_gen.go,**/models_gen.go,**/generated.go,**/*.gen.go"
+          ignore.glob: "vendor/**,**/client_gen.go,**/models_gen.go,**/generated.go,**/*.gen.go"

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727296349,
-        "narHash": "sha256-C3SRU3GMDNII9l16o4+nkybuxaDX4x5TBypwmmUBCo0=",
+        "lastModified": 1727335715,
+        "narHash": "sha256-1uw3y94dA4l22LkqHRIsb7qr3rV5XdxQFqctINfx8Cc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe866c653c24adf1520628236d4e70bbb2fdd949",
+        "rev": "28b5b8af91ffd2623e995e20aee56510db49001a",
         "type": "github"
       },
       "original": {

--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -1,5 +1,5 @@
 final: prev: rec {
-  go = prev.go_1_22.overrideAttrs
+  go = prev.go_1_23.overrideAttrs
     (finalAttrs: previousAttrs: rec {
       version = "1.23.1";
 
@@ -12,8 +12,8 @@ final: prev: rec {
 
   buildGoModule = prev.buildGoModule.override { go = go; };
 
-  golangci-lint = prev.golangci-lint.override rec {
-    buildGoModule = args: final.buildGoModule (args // rec {
+  golangci-lint = prev.golangci-lint.override {
+    buildGo123Module = args: final.buildGoModule (args // rec {
       version = "1.61.0";
       src = prev.fetchFromGitHub {
         owner = "golangci";
@@ -34,7 +34,7 @@ final: prev: rec {
     });
   };
 
-  mockgen = prev.mockgen.override rec {
+  mockgen = prev.mockgen.override {
     buildGoModule = args: final.buildGoModule (args // rec {
       version = "0.4.0";
       src = final.fetchFromGitHub {
@@ -47,7 +47,7 @@ final: prev: rec {
     });
   };
 
-  golines = final.buildGoModule rec {
+  golines = final.buildGoModule {
     name = "golines";
     version = "0.11.0";
     src = final.fetchFromGitHub {
@@ -89,16 +89,16 @@ final: prev: rec {
 
   gqlgen = final.buildGoModule rec {
     pname = "gqlgen";
-    version = "0.17.49";
+    version = "0.17.54";
 
     src = final.fetchFromGitHub {
       owner = "99designs";
       repo = pname;
       rev = "v${version}";
-      sha256 = "sha256-dHKK21xIc7C0Ei/4+WHrVaDMFikZxHP6hTA8zF9ZEZ8=";
+      sha256 = "sha256-0aoEVvKsdWJd3+aC7NuC6gs81dRRByy2TVrV4l9MdWE=";
     };
 
-    vendorHash = "sha256-1NxgK/4ccUqf0m3rJkM0FXKK5wNJmCeCNnV2FyZVRoQ=";
+    vendorHash = "sha256-wsuep7K5SlkTWCiOuzjrkODZgAsHDa9wO8nnwWQVYco=";
 
     doCheck = false;
 
@@ -114,16 +114,16 @@ final: prev: rec {
 
   gqlgenc = final.buildGoModule rec {
     pname = "gqlgenc";
-    version = "0.24.0";
+    version = "0.25.2";
 
     src = final.fetchFromGitHub {
       owner = "Yamashou";
       repo = pname;
       rev = "v${version}";
-      sha256 = "sha256-tKEHqo7drOwHIRCgKEXbELi0u9uRpXSwB9R1fPhv/PE=";
+      sha256 = "sha256-g+l493Nt0SuW4gwJh0s9Zeejpyx2oLxVDykIvBup638=";
     };
 
-    vendorHash = "sha256-lQ2KQF+55qvscnYfm1jLK/4DdwFBaRZmv9oa/BUSoXI=";
+    vendorHash = "sha256-YGFMQrxghJIgmiwEPfEqaACH7OETVkD8O7oUhm9foJo=";
 
     doCheck = false;
 
@@ -137,18 +137,18 @@ final: prev: rec {
     };
   };
 
-  oapi-codegen = prev.oapi-codegen.override rec {
+  oapi-codegen = prev.oapi-codegen.override {
     buildGoModule = args: final.buildGoModule (args // rec {
-      version = "2.3.0";
+      version = "2.4.0";
       src = final.fetchFromGitHub {
         owner = "oapi-codegen";
         repo = "oapi-codegen";
         rev = "v${version}";
-        sha256 = "sha256-Gcl0i3K2ncrxMSLHCPWBleRGdVIVkUo7vcp+tDNpkOw=";
+        sha256 = "sha256-Byb4bTtdn2Xi5hZXsAtcXA868VGQO6RORj1M2x8EAzg=";
       };
 
       subPackages = [ "cmd/oapi-codegen" ];
-      vendorHash = "sha256-urPMLEaisgndbHmS1sGQ07c+VRBdxIz0wseLoSLVWQo=";
+      vendorHash = "sha256-bp5sFZNJFQonwfF1RjCnOMKZQkofHuqG0bXdG5Hf3jU=";
     });
   };
 

--- a/overlays/nhost-cli.nix
+++ b/overlays/nhost-cli.nix
@@ -1,27 +1,27 @@
 { final }:
 let
-  version = "v1.24.1";
+  version = "v1.24.5";
   dist = {
-    aarch64-darwin = rec {
+    aarch64-darwin = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-darwin-arm64.tar.gz";
-      sha256 = "0j3kjz4hhxihg3w99qay74k8aslxnlgwvzvj8p3dindrd98h7pvn";
+      sha256 = "0yswxz8q15cbsrcxfhx8yx4p0igp5ym9d2gy682ighfgbbiny1j4";
     };
-    x86_64-darwin = rec {
+    x86_64-darwin = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-darwin-amd64.tar.gz";
-      sha256 = "118czg3pnj6j617dxvn5skl7012zadgq6ybkbhgcllwjk3glxavv";
+      sha256 = "0w15zlas5975z1p4shs02ggz9f2smlnpmsajjbwb3bsanqgj13q5";
     };
-    aarch64-linux = rec {
+    aarch64-linux = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-linux-arm64.tar.gz";
-      sha256 = "1yj5zajaf2dfvflxkzfhnym2f2vpssmvd2d1kyb97ml8wqgw3mk9";
+      sha256 = "1andq57s8l5ax1i04djb7ck5gd046ilcm00ysfxn0128fydv6ida";
     };
-    x86_64-linux = rec {
+    x86_64-linux = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-linux-amd64.tar.gz";
-      sha256 = "0m7h63clp0p4fycvyxad2mpwa6gfvr9s196j4lijbc1nfwqd4bp6";
+      sha256 = "11n82j432ly8m8ap7bihy93dbc8jwq7lf1mb8hfzzprrzcsw1p96";
     };
   };
 
 in
-final.stdenvNoCC.mkDerivation rec {
+final.stdenvNoCC.mkDerivation {
   pname = "nhost-cli";
   inherit version;
 

--- a/overlays/postgres.nix
+++ b/overlays/postgres.nix
@@ -1,13 +1,4 @@
 final: prev: rec {
-  locales = prev.glibcLocales.override {
-    allLocales = false;
-    locales = [
-      "en_US.UTF-8/UTF-8"
-      "C.UTF-8/UTF-8"
-    ];
-  };
-
-
   postgresql_14_13 = prev.postgresql_14.overrideAttrs
     (finalAttrs: previousAttrs: rec {
       pname = "postgresql";
@@ -45,15 +36,8 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      postFixup = final.lib.optionalString final.stdenv.hostPlatform.isGnu
-        ''
-          wrapProgram $out/bin/pg_dump --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/pg_dumpall --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/pg_restore --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/psql --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-        '';
-      outputs = [ "out" "lib" "dev" ];
-
+      # postFixup = "";
+      # outputs = [ "out" "lib" "dev" ];
     });
 
   postgresql_15_8 = prev.postgresql_15.overrideAttrs
@@ -93,15 +77,8 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      postFixup = final.lib.optionalString final.stdenv.hostPlatform.isGnu
-        ''
-          wrapProgram $out/bin/pg_dump --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/pg_dumpall --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/pg_restore --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/psql --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-        '';
-      outputs = [ "out" "lib" "dev" ];
-
+      # postFixup = "";
+      # outputs = [ "out" "lib" "dev" ];
     });
 
   postgresql_16_4 = prev.postgresql_16.overrideAttrs
@@ -142,13 +119,7 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      postFixup = final.lib.optionalString final.stdenv.hostPlatform.isGnu
-        ''
-          wrapProgram $out/bin/pg_dump --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/pg_dumpall --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/pg_restore --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-          wrapProgram $out/bin/psql --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
-        '';
-      outputs = [ "out" "lib" "dev" ];
+      # postFixup = ""; # this may need fixing to add locales
+      # outputs = [ "out" "lib" "dev" ];
     });
 }

--- a/overlays/postgres.nix
+++ b/overlays/postgres.nix
@@ -10,35 +10,22 @@ final: prev: rec {
       };
     });
 
-  postgresql_14_13-client = postgresql_14_13.overrideAttrs
-    (finalAttrs: previousAttrs: {
-      buildInputs = with final.pkgs; [ zlib openssl ];
-      configureFlags = [
-        "--with-openssl"
-        "--without-readline"
-        "--sysconfdir=/etc"
-        "--libdir=$(lib)/lib"
-        "--with-system-tzdata=${final.pkgs.tzdata}/share/zoneinfo"
-      ];
+  postgresql_14_13-client = final.stdenv.mkDerivation {
+    pname = "postgresql-client";
+    version = postgresql_14_13.version;
 
-      separateDebugInfo = false;
-      buildFlags = [ ];
-      installTargets = [ "-C src/bin install" "-C ../interfaces install" ];
+    buildInputs = [ postgresql_14_13 ];
 
-      postInstall =
-        ''
-          cp src/bin/pg_dump/pg_dump $out/bin
-          cp src/bin/pg_dump/pg_restore $out/bin
-          cp src/bin/psql/psql $out/bin
-          moveToOutput "lib/pgxs" "$out" # looks strange, but not deleting it
-          moveToOutput "lib/libpgcommon*.a" "$out"
-          moveToOutput "lib/libpgport*.a" "$out"
-          moveToOutput "lib/libecpg*" "$out"
-        '';
+    phases = [ "installPhase" ];
 
-      postFixup = "";
-      outputs = [ "out" "lib" "dev" ];
-    });
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${postgresql_14_13}/bin/psql $out/bin/
+      cp ${postgresql_14_13}/bin/pg_dump $out/bin/
+      cp ${postgresql_14_13}/bin/pg_dumpall $out/bin/
+      cp ${postgresql_14_13}/bin/pg_restore $out/bin/
+    '';
+  };
 
   postgresql_15_8 = prev.postgresql_15.overrideAttrs
     (finalAttrs: previousAttrs: rec {
@@ -51,35 +38,22 @@ final: prev: rec {
       };
     });
 
-  postgresql_15_8-client = postgresql_15_8.overrideAttrs
-    (finalAttrs: previousAttrs: {
-      buildInputs = with final.pkgs; [ zlib openssl ];
-      configureFlags = [
-        "--with-openssl"
-        "--without-readline"
-        "--sysconfdir=/etc"
-        "--libdir=$(lib)/lib"
-        "--with-system-tzdata=${final.pkgs.tzdata}/share/zoneinfo"
-      ];
+  postgresql_15_8-client = final.stdenv.mkDerivation {
+    pname = "postgresql-client";
+    version = postgresql_15_8.version;
 
-      separateDebugInfo = false;
-      buildFlags = [ ];
-      installTargets = [ "-C src/bin install" "-C ../interfaces install" ];
+    buildInputs = [ postgresql_15_8 ];
 
-      postInstall =
-        ''
-          cp src/bin/pg_dump/pg_dump $out/bin
-          cp src/bin/pg_dump/pg_restore $out/bin
-          cp src/bin/psql/psql $out/bin
-          moveToOutput "lib/pgxs" "$out" # looks strange, but not deleting it
-          moveToOutput "lib/libpgcommon*.a" "$out"
-          moveToOutput "lib/libpgport*.a" "$out"
-          moveToOutput "lib/libecpg*" "$out"
-        '';
+    phases = [ "installPhase" ];
 
-      postFixup = "";
-      outputs = [ "out" "lib" "dev" ];
-    });
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${postgresql_15_8}/bin/psql $out/bin/
+      cp ${postgresql_15_8}/bin/pg_dump $out/bin/
+      cp ${postgresql_15_8}/bin/pg_dumpall $out/bin/
+      cp ${postgresql_15_8}/bin/pg_restore $out/bin/
+    '';
+  };
 
   postgresql_16_4 = prev.postgresql_16.overrideAttrs
     (finalAttrs: previousAttrs: rec {
@@ -92,34 +66,20 @@ final: prev: rec {
       };
     });
 
-  postgresql_16_4-client = postgresql_16_4.overrideAttrs
-    (finalAttrs: previousAttrs: {
-      buildInputs = with final.pkgs; [ zlib openssl icu ];
-      configureFlags = [
-        "--with-openssl"
-        "--without-readline"
-        "--sysconfdir=/etc"
-        "--libdir=$(lib)/lib"
-        "--with-system-tzdata=${final.pkgs.tzdata}/share/zoneinfo"
-      ] ++ final.lib.optionals final.stdenv.isDarwin [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ];
+  postgresql_16_4-client = final.stdenv.mkDerivation {
+    pname = "postgresql-client";
+    version = postgresql_16_4.version;
 
-      separateDebugInfo = false;
-      buildFlags = [ ];
-      installTargets = [ "-C src/bin install" "-C ../interfaces install" ];
+    buildInputs = [ postgresql_16_4 ];
 
-      postInstall =
-        ''
-          cp src/bin/pg_dump/pg_dump $out/bin
-          cp src/bin/pg_dump/pg_dumpall $out/bin
-          cp src/bin/pg_dump/pg_restore $out/bin
-          cp src/bin/psql/psql $out/bin
-          moveToOutput "lib/pgxs" "$out" # looks strange, but not deleting it
-          moveToOutput "lib/libpgcommon*.a" "$out"
-          moveToOutput "lib/libpgport*.a" "$out"
-          moveToOutput "lib/libecpg*" "$out"
-        '';
+    phases = [ "installPhase" ];
 
-      postFixup = ""; # this may need fixing to add locales
-      outputs = [ "out" "lib" "dev" ];
-    });
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${postgresql_16_4}/bin/psql $out/bin/
+      cp ${postgresql_16_4}/bin/pg_dump $out/bin/
+      cp ${postgresql_16_4}/bin/pg_dumpall $out/bin/
+      cp ${postgresql_16_4}/bin/pg_restore $out/bin/
+    '';
+  };
 }

--- a/overlays/postgres.nix
+++ b/overlays/postgres.nix
@@ -1,4 +1,13 @@
 final: prev: rec {
+  locales = prev.glibcLocales.override {
+    allLocales = false;
+    locales = [
+      "en_US.UTF-8/UTF-8"
+      "C.UTF-8/UTF-8"
+    ];
+  };
+
+
   postgresql_14_13 = prev.postgresql_14.overrideAttrs
     (finalAttrs: previousAttrs: rec {
       pname = "postgresql";
@@ -36,7 +45,15 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
+      postFixup = final.lib.optionalString final.stdenv.hostPlatform.isGnu
+        ''
+          wrapProgram $out/bin/pg_dump --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/pg_dumpall --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/pg_restore --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/psql --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+        '';
       outputs = [ "out" "lib" "dev" ];
+
     });
 
   postgresql_15_8 = prev.postgresql_15.overrideAttrs
@@ -76,7 +93,15 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
+      postFixup = final.lib.optionalString final.stdenv.hostPlatform.isGnu
+        ''
+          wrapProgram $out/bin/pg_dump --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/pg_dumpall --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/pg_restore --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/psql --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+        '';
       outputs = [ "out" "lib" "dev" ];
+
     });
 
   postgresql_16_4 = prev.postgresql_16.overrideAttrs
@@ -117,6 +142,13 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
+      postFixup = final.lib.optionalString final.stdenv.hostPlatform.isGnu
+        ''
+          wrapProgram $out/bin/pg_dump --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/pg_dumpall --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/pg_restore --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+          wrapProgram $out/bin/psql --prefix LOCALE_ARCHIVE ${locales}/lib/locale/locale-archive
+        '';
       outputs = [ "out" "lib" "dev" ];
     });
 }

--- a/overlays/postgres.nix
+++ b/overlays/postgres.nix
@@ -36,8 +36,7 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      postFixup = "";
-      outputs = [ "out" "lib" ];
+      outputs = [ "out" "lib" "dev" ];
     });
 
   postgresql_15_8 = prev.postgresql_15.overrideAttrs
@@ -77,8 +76,7 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      postFixup = "";
-      outputs = [ "out" "lib" ];
+      outputs = [ "out" "lib" "dev" ];
     });
 
   postgresql_16_4 = prev.postgresql_16.overrideAttrs
@@ -119,7 +117,6 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      postFixup = "";
-      outputs = [ "out" "lib" ];
+      outputs = [ "out" "lib" "dev" ];
     });
 }

--- a/overlays/postgres.nix
+++ b/overlays/postgres.nix
@@ -36,8 +36,8 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      # postFixup = "";
-      # outputs = [ "out" "lib" "dev" ];
+      postFixup = "";
+      outputs = [ "out" "lib" "dev" ];
     });
 
   postgresql_15_8 = prev.postgresql_15.overrideAttrs
@@ -77,8 +77,8 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      # postFixup = "";
-      # outputs = [ "out" "lib" "dev" ];
+      postFixup = "";
+      outputs = [ "out" "lib" "dev" ];
     });
 
   postgresql_16_4 = prev.postgresql_16.overrideAttrs
@@ -101,7 +101,7 @@ final: prev: rec {
         "--sysconfdir=/etc"
         "--libdir=$(lib)/lib"
         "--with-system-tzdata=${final.pkgs.tzdata}/share/zoneinfo"
-      ];
+      ] ++ final.lib.optionals final.stdenv.isDarwin [ "LDFLAGS_EX_BE=-Wl,-export_dynamic" ];
 
       separateDebugInfo = false;
       buildFlags = [ ];
@@ -119,7 +119,7 @@ final: prev: rec {
           moveToOutput "lib/libecpg*" "$out"
         '';
 
-      # postFixup = ""; # this may need fixing to add locales
-      # outputs = [ "out" "lib" "dev" ];
+      postFixup = ""; # this may need fixing to add locales
+      outputs = [ "out" "lib" "dev" ];
     });
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated Go version from 1.22 to 1.23 and related tools (golangci-lint, mockgen, gqlgen, gqlgenc, oapi-codegen) to their latest versions in `overlays/go.nix`.
- Upgraded nhost-cli to version 1.24.5 and updated corresponding SHA256 hashes for all platforms in `overlays/nhost-cli.nix`.
- Enhanced PostgreSQL overlay with locale support:
  - Added specific UTF-8 locales configuration.
  - Updated postFixup for all PostgreSQL versions to include locale archive wrapping.
  - Added 'dev' to outputs for better package management.
- Modified AI review workflow configuration in `.github/workflows/gen_ai_review.yaml` to use 'ignore.glob' instead of 'config.ignore.glob'.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Update Go and related tools versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/go.nix

<li>Updated Go version from 1.22 to 1.23<br> <li> Updated golangci-lint, mockgen, gqlgen, gqlgenc, and oapi-codegen <br>versions<br> <li> Minor syntax improvements and variable renaming<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/24/files#diff-46da9fc0b23a2984c1ff57bfd4063ad81fccffcc8403f6902d186d679b4e52bd">+15/-15</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nhost-cli.nix</strong><dd><code>Upgrade nhost-cli to version 1.24.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/nhost-cli.nix

<li>Updated nhost-cli version from v1.24.1 to v1.24.5<br> <li> Updated SHA256 hashes for all platform-specific downloads<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/24/files#diff-30af032272047cf9f8b0556d4e2b31c5a883c5dc27839f3fae1f4e358da760b2">+10/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postgres.nix</strong><dd><code>Enhance PostgreSQL overlay with locale support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/postgres.nix

<li>Added locales configuration for specific UTF-8 locales<br> <li> Updated postFixup for PostgreSQL versions to include locale archive <br>wrapping<br> <li> Added 'dev' to outputs for all PostgreSQL versions<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/24/files#diff-7f41ebcea5532fee815408ee6bef896c63123c003f7b491c41a69ab003612ce4">+35/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gen_ai_review.yaml</strong><dd><code>Update AI review workflow configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/gen_ai_review.yaml

<li>Changed 'config.ignore.glob' to 'ignore.glob' in the workflow <br>configuration<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/24/files#diff-d1e4c772e0acb5ce4891df2dd94ba58ffaf6393e8f75493ec7e10cbce1c4992c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information