### PR TITLE
chore: update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "lastModified": 1731533336,
+        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727335715,
-        "narHash": "sha256-1uw3y94dA4l22LkqHRIsb7qr3rV5XdxQFqctINfx8Cc=",
+        "lastModified": 1732238832,
+        "narHash": "sha256-sQxuJm8rHY20xq6Ah+GwIUkF95tWjGRd1X8xF+Pkk38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "28b5b8af91ffd2623e995e20aee56510db49001a",
+        "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
         "type": "github"
       },
       "original": {

--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -13,7 +13,7 @@ final: prev: rec {
   buildGoModule = prev.buildGoModule.override { go = go; };
 
   golangci-lint = prev.golangci-lint.override {
-    buildGo123Module = args: final.buildGoModule (args // rec {
+    buildGoModule = args: final.buildGoModule (args // rec {
       version = "1.61.0";
       src = prev.fetchFromGitHub {
         owner = "golangci";


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated `golangci-lint` to use `buildGoModule` instead of `buildGo123Module`.
- Set `golangci-lint` version to "1.61.0".



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Update `golangci-lint` to use `buildGoModule` and set version</code></dd></summary>
<hr>

overlays/go.nix

<li>Updated <code>golangci-lint</code> to use <code>buildGoModule</code> instead of <br><code>buildGo123Module</code>.<br> <li> Set <code>golangci-lint</code> version to "1.61.0".<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/27/files#diff-46da9fc0b23a2984c1ff57bfd4063ad81fccffcc8403f6902d186d679b4e52bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information