### PR TITLE
fix: use an older commit to avoid cold hydra cache issues

### DIFF
--- a/.github/workflows/push_build_devShells.yaml
+++ b/.github/workflows/push_build_devShells.yaml
@@ -10,7 +10,7 @@ jobs:
   artifacts:
     strategy:
       matrix:
-        os: [blacksmith-2vcpu-ubuntu-2204, blacksmith-2vcpu-ubuntu-2204-arm]
+        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-ubuntu-2204-arm]
       fail-fast: true
 
     runs-on: ${{ matrix.os }}

--- a/flake.lock
+++ b/flake.lock
@@ -35,17 +35,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737942377,
-        "narHash": "sha256-8Eo/jRAgT3CbAloyqOj6uPN1EqBvLI/Tv2g+RxHjkhU=",
+        "lastModified": 1735772274,
+        "narHash": "sha256-+P8XU9VxOjeCaThkzHfMdUqitd0hS4Cx7y4pxyR58pw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88a55dffa4d44d294c74c298daf75824dc0aafb5",
+        "rev": "d29975d32b1dc7fe91d5cb275d20f8f8aba399ad",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "d29975d32b1dc7fe91d5cb275d20f8f8aba399ad",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Nhost's nix operations";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d29975d32b1dc7fe91d5cb275d20f8f8aba399ad";
     flake-utils.url = "github:numtide/flake-utils";
     nix-filter.url = "github:numtide/nix-filter";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -52,10 +52,10 @@
               postgresql_15_10-client
               postgresql_16_6-client
               postgresql_17_2-client
-              # postgresql_14_15
-              # postgresql_15_10
-              # postgresql_16_6
-              # postgresql_17_2
+              postgresql_14_15
+              postgresql_15_10
+              postgresql_16_6
+              postgresql_17_2
             ];
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -48,9 +48,9 @@
               gqlgenc
               oapi-codegen
               nhost-cli
-              # postgresql_14_15-client
-              # postgresql_15_10-client
-              # postgresql_16_6-client
+              postgresql_14_15-client
+              postgresql_15_10-client
+              postgresql_16_6-client
               postgresql_17_2-client
               # postgresql_14_15
               # postgresql_15_10

--- a/overlays/postgres.nix
+++ b/overlays/postgres.nix
@@ -5,6 +5,7 @@ final: prev: rec {
       version = "14.15";
 
       doCheck = false;
+      doInstallCheck = false;
 
       src = final.fetchurl {
         url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
@@ -35,6 +36,7 @@ final: prev: rec {
       version = "15.10";
 
       doCheck = false;
+      doInstallCheck = false;
 
       src = final.fetchurl {
         url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
@@ -65,6 +67,7 @@ final: prev: rec {
       version = "16.6";
 
       doCheck = false;
+      doInstallCheck = false;
 
       src = final.fetchurl {
         url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";

--- a/overlays/postgres.nix
+++ b/overlays/postgres.nix
@@ -4,6 +4,8 @@ final: prev: rec {
       pname = "postgresql";
       version = "14.15";
 
+      doCheck = false;
+
       src = final.fetchurl {
         url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
         hash = "sha256-AuiR4xS06e4ky9eAKNq3xz+cG6PjCDW8vvcf4iBAH8U=";
@@ -31,6 +33,8 @@ final: prev: rec {
     (finalAttrs: previousAttrs: rec {
       pname = "postgresql";
       version = "15.10";
+
+      doCheck = false;
 
       src = final.fetchurl {
         url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
@@ -60,6 +64,8 @@ final: prev: rec {
       pname = "postgresql";
       version = "16.6";
 
+      doCheck = false;
+
       src = final.fetchurl {
         url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
         hash = "sha256-Izac2szUUnCsXcww+p2iBdW+M/pQXh8XoEGNLK7KR3s=";
@@ -87,6 +93,8 @@ final: prev: rec {
     (finalAttrs: previousAttrs: rec {
       pname = "postgresql";
       version = "17.2";
+
+      doCheck = false;
 
       src = final.fetchurl {
         url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Uncomment PostgreSQL client packages in flake.nix

- Enable multiple PostgreSQL client versions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flake.nix</strong><dd><code>Enable multiple PostgreSQL client versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flake.nix

<li>Uncommented PostgreSQL client packages for versions 14.15, 15.10, and <br>16.6<br> <li> Kept PostgreSQL client 17.2 and server packages commented out


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/31/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>