### PR TITLE
fix: update mechanism to pass cgo to golang

### DIFF
--- a/lib/go/example/flake.nix
+++ b/lib/go/example/flake.nix
@@ -61,23 +61,19 @@
 
           example-arm64-darwin = (nixops-lib.go.package {
             inherit name src version ldflags buildInputs nativeBuildInputs;
-            cgoEnabled = 0;
-          }).overrideAttrs (old: old // { GOOS = "darwin"; GOARCH = "arm64"; });
+          }).overrideAttrs (old: old // { GOOS = "darwin"; GOARCH = "arm64"; CGO_ENABLED = "0"; });
 
           example-amd64-darwin = (nixops-lib.go.package {
             inherit name src version ldflags buildInputs nativeBuildInputs;
-            cgoEnabled = 0;
-          }).overrideAttrs (old: old // { GOOS = "darwin"; GOARCH = "amd64"; });
+          }).overrideAttrs (old: old // { GOOS = "darwin"; GOARCH = "amd64"; GO_ENABLED = "0"; });
 
           example-arm64-linux = (nixops-lib.go.package {
             inherit name src version ldflags buildInputs nativeBuildInputs;
-            cgoEnabled = 0;
-          }).overrideAttrs (old: old // { GOOS = "linux"; GOARCH = "arm64"; });
+          }).overrideAttrs (old: old // { GOOS = "linux"; GOARCH = "arm64"; CGO_ENABLED = "0"; });
 
           example-amd64-linux = (nixops-lib.go.package {
             inherit name src version ldflags buildInputs nativeBuildInputs;
-            cgoEnabled = 0;
-          }).overrideAttrs (old: old // { GOOS = "linux"; GOARCH = "amd64"; });
+          }).overrideAttrs (old: old // { GOOS = "linux"; GOARCH = "amd64"; CGO_ENABLED = "0"; });
 
           docker-image = nixops-lib.go.docker-image {
             inherit name version buildInputs;

--- a/lib/go/go.nix
+++ b/lib/go/go.nix
@@ -90,7 +90,6 @@ in
     , ldflags
     , buildInputs
     , nativeBuildInputs
-    , cgoEnabled ? 1
     , postInstall ? ""
     }: (pkgs.buildGoModule {
       inherit src version ldflags buildInputs nativeBuildInputs;
@@ -102,8 +101,6 @@ in
       doCheck = false;
 
       subPackages = [ submodule ];
-
-      CGO_ENABLED = cgoEnabled;
 
       postInstall = postInstall;
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update CGO_ENABLED setting in package overrides

- Remove cgoEnabled parameter from go.nix

- Correct typo in CGO_ENABLED for amd64-darwin

- Streamline package definitions in flake.nix


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flake.nix</strong><dd><code>Update CGO settings in package overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/go/example/flake.nix

<li>Replace <code>cgoEnabled = 0</code> with <code>CGO_ENABLED = "0"</code> in package overrides<br> <li> Fix typo: <code>GO_ENABLED = "0"</code> to <code>CGO_ENABLED = "0"</code> for amd64-darwin<br> <li> Simplify package definitions by moving CGO_ENABLED to overrideAttrs


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/32/files#diff-1bc514d2d6450586523d4da49b8887d78a3db98124cc72bc1c6b0828a1fbf291">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Remove cgoEnabled parameter from go.nix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/go/go.nix

<li>Remove <code>cgoEnabled</code> parameter from function definition<br> <li> Remove <code>CGO_ENABLED = cgoEnabled;</code> line from buildGoModule


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/32/files#diff-1377128cceefd42b43cd5e407ec11a809c7aaec2d071a1ed0e3232f6dce63fad">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>