### PR TITLE
chore: bump go due to vuln GO-2025-3447

### DIFF
--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -1,11 +1,11 @@
 final: prev: rec {
   go = prev.go_1_23.overrideAttrs
     (finalAttrs: previousAttrs: rec {
-      version = "1.23.5";
+      version = "1.23.6";
 
       src = final.fetchurl {
         url = "https://go.dev/dl/go${version}.src.tar.gz";
-        sha256 = "sha256-pvP0u9PmvdYm95tmjyEvu1ZJ2vdQhPt5tnigrk2XQjs=";
+        sha256 = "sha256-A5xbBOZSedrO7opvcecL0Fz1uAF4K293xuGeLtBREiI=";
       };
 
     });


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update Go version from 1.23.5 to 1.23.6

- Address vulnerability GO-2025-3447

- Update SHA256 hash for new Go source


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Update Go version and source hash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/go.nix

<li>Bumped Go version from 1.23.5 to 1.23.6<br> <li> Updated SHA256 hash for the new Go source


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/35/files#diff-46da9fc0b23a2984c1ff57bfd4063ad81fccffcc8403f6902d186d679b4e52bd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>