### PR TITLE
chore: bump go and nhost cli

### DIFF
--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -1,11 +1,11 @@
 final: prev: rec {
   go = prev.go_1_23.overrideAttrs
     (finalAttrs: previousAttrs: rec {
-      version = "1.23.6";
+      version = "1.23.8";
 
       src = final.fetchurl {
         url = "https://go.dev/dl/go${version}.src.tar.gz";
-        sha256 = "sha256-A5xbBOZSedrO7opvcecL0Fz1uAF4K293xuGeLtBREiI=";
+        sha256 = "sha256-DKHx436iVePOKDrz9OYoUC+0RFh9qYelu5bWxvFZMNQ=";
       };
 
     });

--- a/overlays/nhost-cli.nix
+++ b/overlays/nhost-cli.nix
@@ -1,22 +1,22 @@
 { final }:
 let
-  version = "v1.29.0";
+  version = "v1.29.5";
   dist = {
     aarch64-darwin = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-darwin-arm64.tar.gz";
-      sha256 = "1sbsxsw2zm2rbx5ksnjwq68b2igab9qa1fj12r32r8vs8xwn5320";
+      sha256 = "036kz31ggkk9lil1ykp9scyykl5sx8snh8q0l8ldwcp1n0l7xh3l";
     };
     x86_64-darwin = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-darwin-amd64.tar.gz";
-      sha256 = "1gn097knda33i2baqskf3awb4zjmvvpfrj8qfmr4fwncwpgsr0ak";
+      sha256 = "00ry1d12lw7ibzp3sykvy7ph8zgbybhha21rfwjq1gnjk6kgxgh6";
     };
     aarch64-linux = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-linux-arm64.tar.gz";
-      sha256 = "1p7zibfpl283syi8v0b1kdk0js05simhpvndg3ylxg8x4p42hgp4";
+      sha256 = "1svppmf2bc7yv1lz0bdphqpp7530kp1k3jlk5jzb1wz288zrmz5h";
     };
     x86_64-linux = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-linux-amd64.tar.gz";
-      sha256 = "1m8wp8l2q4b9qa12ix03nadphyvy5dqawq64m19cnz5sg7vdg261";
+      sha256 = "11zai2hayv95jpv0a3pbqmj79qkbvzfhpbga6i16j88n7an3lsks";
     };
   };
 


### PR DESCRIPTION
### **User description**
They are both outdated and go just published a CVE that needs upgrading.


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade Go to version 1.24.2

- Update Nhost CLI to version 1.29.5

- Update SHA256 hashes for both packages

- Address potential security vulnerability in Go


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Upgrade Go to version 1.24.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/go.nix

<li>Update Go version from 1.23.6 to 1.24.2<br> <li> Update SHA256 hash for the new Go version


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/36/files#diff-46da9fc0b23a2984c1ff57bfd4063ad81fccffcc8403f6902d186d679b4e52bd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nhost-cli.nix</strong><dd><code>Update Nhost CLI to version 1.29.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/nhost-cli.nix

<li>Update Nhost CLI version from 1.29.0 to 1.29.5<br> <li> Update SHA256 hashes for all supported platforms


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/36/files#diff-30af032272047cf9f8b0556d4e2b31c5a883c5dc27839f3fae1f4e358da760b2">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>