### PR TITLE
fix: vulncheck: use -scan=package to reduce memory usage

### DIFF
--- a/lib/go/go.nix
+++ b/lib/go/go.nix
@@ -63,7 +63,7 @@ in
         golines -l --base-formatter=gofumpt . | diff - /dev/null
 
         echo "➜ Checking for vulnerabilities"
-        govulncheck ./${submodule}/...
+        govulncheck -scan=package ./...
 
         echo "➜ Running golangci-lint"
         golangci-lint run \


### PR DESCRIPTION
### **User description**
Not as fine grained results leading to false positives but much faster and with much less RAM requirements


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated `govulncheck` command to use `-scan=package` for reduced memory usage.

- Improved performance and memory efficiency during vulnerability checks.

- Adjusted the vulnerability scanning process to balance granularity and resource usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Update `govulncheck` to use `-scan=package`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/go/go.nix

<li>Modified <code>govulncheck</code> command to include <code>-scan=package</code>.<br> <li> Enhanced memory efficiency during vulnerability checks.<br> <li> Adjusted scanning scope to improve performance.


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/37/files#diff-1377128cceefd42b43cd5e407ec11a809c7aaec2d071a1ed0e3232f6dce63fad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>