### PR TITLE
fix: revert golang 2x due to many issues

### DIFF
--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -14,15 +14,15 @@ final: prev: rec {
 
   golangci-lint = prev.golangci-lint.override {
     buildGo124Module = args: final.buildGo124Module (args // rec {
-      version = "2.1.5";
+      version = "1.64.8";
       src = prev.fetchFromGitHub {
         owner = "golangci";
         repo = "golangci-lint";
         rev = "v${version}";
-        sha256 = "sha256-wCBGtKlaKW6Btim9xe0K8IzdNVcBDEidhr6LCwLUx98=";
+        sha256 = "sha256-H7IdXAleyzJeDFviISitAVDNJmiwrMysYcGm6vAoWso=";
       };
 
-      vendorHash = "sha256-Dd4GTjkq1LTH7G1Qj8y+q0LW/8cQECN8o+3xHFtmpwI=";
+      vendorHash = "sha256-i7ec4U4xXmRvHbsDiuBjbQ0xP7xRuilky3gi+dT1H10=";
 
       ldflags = [
         "-s"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Revert golangci-lint to version 1.64.8

- Update SHA256 hashes for source and vendor


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Revert golangci-lint version and update hashes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/go.nix

<li>Downgrade golangci-lint version from 2.1.5 to 1.64.8<br> <li> Update SHA256 hash for source repository<br> <li> Update vendorHash for dependencies


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/39/files#diff-46da9fc0b23a2984c1ff57bfd4063ad81fccffcc8403f6902d186d679b4e52bd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>