### PR TITLE
chore: update nhost and increase golangci-lint timeout

### DIFF
--- a/lib/go/go.nix
+++ b/lib/go/go.nix
@@ -67,7 +67,7 @@ in
 
         echo "➜ Running golangci-lint"
         golangci-lint run \
-          --timeout 300s \
+          --timeout 600s \
           ./${submodule}/...
 
         echo "➜ Running tests"

--- a/overlays/nhost-cli.nix
+++ b/overlays/nhost-cli.nix
@@ -1,22 +1,22 @@
 { final }:
 let
-  version = "v1.29.7";
+  version = "v1.29.8";
   dist = {
     aarch64-darwin = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-darwin-arm64.tar.gz";
-      sha256 = "00pr4p3a7h534nrvyd4jljij2h8jn2sw8pypnj0zn60cwc38wzxj";
+      sha256 = "0m3hwnzvkv2kbhf1y2hfv2mhiwvcywi6jmq5d60fphhl1b3y99zm";
     };
     x86_64-darwin = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-darwin-amd64.tar.gz";
-      sha256 = "1hj21xhkxayf73xh57ldj5g5sgmv3lb5kw37p3l86q6r2in3x486";
+      sha256 = "1bq66cbppw36jriwwrfqqvnaqn370vkr99jwhvb8cg0j79ly87xg";
     };
     aarch64-linux = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-linux-arm64.tar.gz";
-      sha256 = "1wgn6wvq2xlmf3i3hid31znzpln93q87kzn2wsqb2grl1bjkak1y";
+      sha256 = "083fwr33l87y51w5wczv3269k7f0iq2srw8rbd3qw1xlwms9x6q3";
     };
     x86_64-linux = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-linux-amd64.tar.gz";
-      sha256 = "0cn6bp3cdpjpiak7pbjqrcyrkszlj7h4a2drawbs258amd8q2m5k";
+      sha256 = "08nhnnnbcv1mlbi2pigjgknyqyibp5xcp99z28am8qs2vi05kb93";
     };
   };
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Increased golangci-lint timeout from 300s to 600s

- Updated nhost CLI to version v1.29.8

- Updated SHA256 hashes for nhost CLI binaries


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Increase golangci-lint timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/go/go.nix

- Increased golangci-lint timeout from 300s to 600s


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/42/files#diff-1377128cceefd42b43cd5e407ec11a809c7aaec2d071a1ed0e3232f6dce63fad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nhost-cli.nix</strong><dd><code>Update nhost CLI to v1.29.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/nhost-cli.nix

<li>Updated nhost CLI version from v1.29.7 to v1.29.8<br> <li> Updated SHA256 hashes for all supported platforms


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/42/files#diff-30af032272047cf9f8b0556d4e2b31c5a883c5dc27839f3fae1f4e358da760b2">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>