### PR TITLE
fix: added ca cert env var

### DIFF
--- a/lib/go/go.nix
+++ b/lib/go/go.nix
@@ -28,7 +28,6 @@ let
       copyToRoot = pkgs.buildEnv {
         name = "image";
         paths = [
-          pkgs.cacert
           package
           (pkgs.writeTextFile {
             name = "tmp-file";


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Add `SSL_CERT_FILE` environment variable to Go container images.

- Ensure Go images use correct CA certificate path.

- Remove redundant inclusion of `pkgs.cacert` in root filesystem.

- Improve container image configuration for SSL/TLS support.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Improve CA certificate handling in Go container images</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/go/go.nix

<li>Add <code>SSL_CERT_FILE</code> env var pointing to CA bundle.<br> <li> Remove <code>pkgs.cacert</code> from root filesystem paths.<br> <li> Update container image configuration for better SSL support.


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/46/files#diff-1377128cceefd42b43cd5e407ec11a809c7aaec2d071a1ed0e3232f6dce63fad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>