### PR TITLE
chore: udpate cli

### DIFF
--- a/overlays/nhost-cli.nix
+++ b/overlays/nhost-cli.nix
@@ -1,22 +1,22 @@
 { final }:
 let
-  version = "v1.29.8";
+  version = "v1.31.0";
   dist = {
     aarch64-darwin = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-darwin-arm64.tar.gz";
-      sha256 = "0m3hwnzvkv2kbhf1y2hfv2mhiwvcywi6jmq5d60fphhl1b3y99zm";
+      sha256 = "1jynlr7gla4snpcszpkh2vkq47774x5w8js6ghw4s4aa6jp5wcw4";
     };
     x86_64-darwin = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-darwin-amd64.tar.gz";
-      sha256 = "1bq66cbppw36jriwwrfqqvnaqn370vkr99jwhvb8cg0j79ly87xg";
+      sha256 = "1z8w7830yaf3zwy3ajilav1zg9y8x583gjna6z41v32hj04yk55h";
     };
     aarch64-linux = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-linux-arm64.tar.gz";
-      sha256 = "083fwr33l87y51w5wczv3269k7f0iq2srw8rbd3qw1xlwms9x6q3";
+      sha256 = "10z032jxi0vi08p4i12lgb01jr16x0mrki8hhzl2hpbhq97wzmdj";
     };
     x86_64-linux = {
       url = "https://github.com/nhost/cli/releases/download/${version}/cli-${version}-linux-amd64.tar.gz";
-      sha256 = "08nhnnnbcv1mlbi2pigjgknyqyibp5xcp99z28am8qs2vi05kb93";
+      sha256 = "0la5czcqc8wbdvqa8rbqaibf5c07zls9a98ihb950jyx8vwsi2ly";
     };
   };
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update `nhost-cli` version from v1.29.8 to v1.31.0

- Refresh SHA256 hashes for all platform binaries

- Ensure latest CLI release is used in overlay


___

### **Changes diagram**

```mermaid
flowchart LR
  A["nhost-cli.nix (v1.29.8)"] -- "bump version & hashes" --> B["nhost-cli.nix (v1.31.0)"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nhost-cli.nix</strong><dd><code>Bump nhost-cli version and update binary hashes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/nhost-cli.nix

<li>Bump <code>nhost-cli</code> version to v1.31.0<br> <li> Update SHA256 hashes for all supported platforms


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/47/files#diff-30af032272047cf9f8b0556d4e2b31c5a883c5dc27839f3fae1f4e358da760b2">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>