### PR TITLE
fix: use fork of oapi-codegen with fixes

### DIFF
--- a/overlays/go.nix
+++ b/overlays/go.nix
@@ -93,12 +93,12 @@ final: prev: rec {
   };
 
   oapi-codegen = prev.oapi-codegen.overrideAttrs (oldAttrs: rec {
-    version = "2.5.0";
+    version = "2.6.0-beta0";
     src = final.fetchFromGitHub {
-      owner = "oapi-codegen";
+      owner = "dbarrosop";
       repo = "oapi-codegen";
-      rev = "v${version}";
-      hash = "sha256-Z10rJMancQLefyW0wXWaODIKfSY+4b3T+TAro//xsAQ=";
+      rev = "6225e75bb76ba1fa15113a7fc6aace55ad12862c";
+      hash = "sha256-sXmHVIFKxnogdr9qULZ2Io7cQGG6sMMx0ZLskjz1mOc=";
     };
     vendorHash = "sha256-obpY7ZATebI/7bkPMidC83xnN60P0lZsJhSuKr2A5T4=";
   });


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Switch to fork of oapi-codegen with fixes

- Update version from 2.5.0 to 2.6.0-beta0

- Change repository owner from oapi-codegen to dbarrosop

- Update source hash and revision commit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["oapi-codegen v2.5.0"] -- "switch to fork" --> B["dbarrosop/oapi-codegen v2.6.0-beta0"]
  B -- "contains fixes" --> C["Updated dependency"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.nix</strong><dd><code>Switch to forked oapi-codegen dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overlays/go.nix

<ul><li>Switch oapi-codegen dependency to dbarrosop fork<br> <li> Update version from 2.5.0 to 2.6.0-beta0<br> <li> Change repository owner and update source hash<br> <li> Update revision to specific commit hash</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/nixops/pull/49/files#diff-46da9fc0b23a2984c1ff57bfd4063ad81fccffcc8403f6902d186d679b4e52bd">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

